### PR TITLE
attempt to repro unable to custom-name connection type

### DIFF
--- a/OttoTheGeek.Tests/CustomNamedConnectionTests.cs
+++ b/OttoTheGeek.Tests/CustomNamedConnectionTests.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using OttoTheGeek.Connections;
+using OttoTheGeek.RuntimeSchema;
+
+namespace OttoTheGeek.Tests
+{
+    public sealed class CustomNamedConnectionTests
+    {
+        public const string ConnectionTypeName = "CustomChildConnection";
+        public sealed class Query
+        {
+            public IEnumerable<ChildObject> Children { get; set; }
+        }
+
+        public class Model : OttoModel<Query>
+        {
+            protected override SchemaBuilder<Query> ConfigureSchema(SchemaBuilder<Query> builder)
+            {
+                return builder.ConnectionField(x => x.Children)
+                    .ResolvesVia<ChildrenResolver>()
+                    .GraphType<Connection<ChildObject>>(x => x.Named(ConnectionTypeName));
+
+            }
+        }
+
+        public sealed class ChildrenResolver : IConnectionResolver<ChildObject>
+        {
+            public Task<Connection<ChildObject>> Resolve(PagingArgs<ChildObject> args)
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+
+        public sealed class ChildObject
+        {
+            public string Value1 { get; set; }
+        }
+
+        public void HasCustomName()
+        {
+            var server = new Model().CreateServer();
+
+            var rawResult = server.Execute<JObject>(@"{
+                __type(name:""Query"") {
+                    name
+                    kind
+                    fields {
+                        name
+                        type {
+                            name
+                        }
+                    }
+                }
+            }");
+
+            var queryType = rawResult["__type"].ToObject<ObjectType>();
+
+            queryType.Fields
+                .Single()
+                .Type
+                .Name
+                .Should()
+                .Be(ConnectionTypeName);
+        }
+
+    }
+}

--- a/OttoTheGeek.Tests/CustomNamedConnectionTests.cs
+++ b/OttoTheGeek.Tests/CustomNamedConnectionTests.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Newtonsoft.Json.Linq;
 using OttoTheGeek.Connections;
 using OttoTheGeek.RuntimeSchema;
+using Xunit;
 
 namespace OttoTheGeek.Tests
 {
@@ -40,6 +41,7 @@ namespace OttoTheGeek.Tests
             public string Value1 { get; set; }
         }
 
+        [Fact]
         public void HasCustomName()
         {
             var server = new Model().CreateServer();

--- a/OttoTheGeek/GraphTypeBuilder.cs
+++ b/OttoTheGeek/GraphTypeBuilder.cs
@@ -215,9 +215,13 @@ namespace OttoTheGeek
         }
 
         private string GraphTypeName =>
-            IsConnection
-            ? $"{GetConnectionElemType().Name}Connection"
-            : _customName ?? typeof(TModel).Name;
+            _customName
+            ??
+            (
+                IsConnection
+                ? $"{GetConnectionElemType().Name}Connection"
+                : typeof(TModel).Name
+            );
 
         private bool IsConnection => typeof(TModel).IsConstructedGenericType
             && typeof(TModel).GetGenericTypeDefinition() == typeof(Connection<>);


### PR DESCRIPTION
I wrote down that we had trouble custom-naming a `Connection<T>` type in our demo. This was my attempt to repro and fix it. Would love another pair of eyes.