### PR TITLE
Fix lost tracking on OrderBy customizations

### DIFF
--- a/OttoTheGeek/Internal/PropertyMap.cs
+++ b/OttoTheGeek/Internal/PropertyMap.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace OttoTheGeek.Internal
+{
+    public sealed class PropertyMap<TValue>
+    {
+        private IEnumerable<(Type, string, TValue)> _values;
+        public PropertyMap() : this(new (Type, string, TValue)[0])
+        {
+        }
+
+        private PropertyMap(IEnumerable<(Type, string, TValue)> values)
+        {
+            _values = values;
+        }
+
+
+        public PropertyMap<TValue> Add(PropertyInfo key, TValue value)
+        {
+            var newValues = _values
+                .Where(x => !Matches(key, x))
+                .Concat(new[] { (key.DeclaringType, key.Name, value) })
+                .ToArray();
+
+            return new PropertyMap<TValue>(newValues);
+        }
+
+        public TValue Get(PropertyInfo key)
+        {
+            return _values
+                .Where(x => Matches(key, x))
+                .Select(x => x.Item3)
+                .SingleOrDefault();
+        }
+
+        private static bool Matches(PropertyInfo key, (Type, string, TValue) tuple)
+        {
+            return key.DeclaringType == tuple.Item1
+                && key.Name == tuple.Item2;
+        }
+    }
+}


### PR DESCRIPTION
This all hinges upon `PropertyInfo` not working properly as a dictionary key. The new `PropertyMap<T>` class works around that.