### PR TITLE
add strong-typed schema type for DI

### DIFF
--- a/OttoTheGeek/ModelSchema.cs
+++ b/OttoTheGeek/ModelSchema.cs
@@ -1,0 +1,14 @@
+using System.Linq;
+using GraphQL.Types;
+
+namespace OttoTheGeek
+{
+    public sealed class ModelSchema<TQuery> : Schema
+    {
+        public ModelSchema(OttoSchema schema)
+        {
+            Query = schema.QueryType;
+            RegisterTypes(schema.OtherTypes.ToArray());
+        }
+    }
+}

--- a/OttoTheGeek/OttoModel.cs
+++ b/OttoTheGeek/OttoModel.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using GraphQL;
 using GraphQL.DataLoader;
 using GraphQL.Types;
@@ -23,16 +22,11 @@ namespace OttoTheGeek
             return new OttoServer(schema, provider);
         }
 
-        public Schema BuildGraphQLSchema(IServiceCollection services)
+        public ModelSchema<TQuery> BuildGraphQLSchema(IServiceCollection services)
         {
             var ottoSchema = BuildOttoSchema(services);
 
-            var schema = new Schema
-            {
-                Query = ottoSchema.QueryType
-            };
-            schema.RegisterTypes(ottoSchema.OtherTypes.ToArray());
-            return schema;
+            return new ModelSchema<TQuery>(ottoSchema);
         }
 
         public OttoSchema BuildOttoSchema(IServiceCollection services)


### PR DESCRIPTION
Previously, `OttoModel<T>.BuildGraphQLSchema()` returned an instance of `GraphQL.Types.Schema`, which would work _okay_ if you only had a single GraphQL endpoint. In this case, in the `Configure(...)` method, you could configure a GraphQL endpoint via something like:
```csharp
public void Configure(IApplicationBuilder app)
{
    app.UseGraphQL<Schema>(path: "/graphql");
}
```

This PR adds a new type `ModelSchema<TQuery>` which inherits from `GraphQL.Types.Schema`. This change should be backwards-compatible, but should also allow for hosting multiple GraphQL endpoints with different models in the same project. For instance:
```csharp
public void Configure(IApplicationBuilder app)
{
    app
       .UseGraphQL<ModelSchema<PublicQuery>>(path: "/graphql-public")
       .UseGraphQL<ModelSchema<InternalQuery>>(path: "/graphql-internal")
}
```